### PR TITLE
Fix CORS to allow localhost:3001

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -50,7 +50,7 @@ app = FastAPI(title="AI Rubric Evaluator", lifespan=lifespan)
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["http://localhost:3000"],
+    allow_origins=["http://localhost:3000", "http://localhost:3001"],
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],


### PR DESCRIPTION
## Summary
- Adds `http://localhost:3001` to the CORS allowed origins list
- Fixes API calls being blocked when Next.js dev server falls back to port 3001 (when 3000 is already in use)

## Test plan
- [ ] Start backend on port 8000
- [ ] Start frontend (auto-assigns 3001 if 3000 is in use)
- [ ] Confirm upload and polling work without CORS errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)