### PR TITLE
Add primary_improvement field and targeted section feedback

### DIFF
--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -37,6 +37,7 @@ class GradingResult(BaseModel):
     total_awarded: int
     sections: List[SectionScore]
     overall_feedback: str
+    primary_improvement: str
     penalties: List[PenaltyCheck] = []
 
 

--- a/backend/app/services/grading_service.py
+++ b/backend/app/services/grading_service.py
@@ -65,6 +65,12 @@ Grade each section independently. For each section:
 2. Assign a score based on both event alignment and quality of execution; a section that doesn't serve this event's purpose scores in the lower tier regardless of writing quality
 3. Provide specific feedback explaining what was and wasn't fulfilled, and why the score was assigned
 
+PRIMARY IMPROVEMENT:
+After grading all sections, identify the single highest-impact change the student could make to improve their score. Name the specific section, describe the specific idea or approach in the report that is weak or missing, and give a precise directive for what to fix or add. One concrete action — not a general summary.
+
+SECTION FEEDBACK REQUIREMENT:
+For each section, feedback must be specific to what this report actually said or did — not generic advice. Reference the specific idea, argument, plan, or approach the student used and explain precisely why it fell short of the scoring guide. Avoid feedback that could apply to any report.
+
 Return ONLY valid JSON matching the required schema. Do not add commentary outside the JSON structure."""
 
 GRADING_SCHEMA = {
@@ -88,6 +94,7 @@ GRADING_SCHEMA = {
             },
         },
         "overall_feedback": {"type": "string"},
+        "primary_improvement": {"type": "string"},
         "penalties": {
             "type": "array",
             "items": {
@@ -109,6 +116,7 @@ GRADING_SCHEMA = {
         "total_awarded",
         "sections",
         "overall_feedback",
+        "primary_improvement",
         "penalties",
     ],
     "additionalProperties": False,

--- a/frontend/components/ScoreBreakdown.tsx
+++ b/frontend/components/ScoreBreakdown.tsx
@@ -115,6 +115,18 @@ export default function ScoreBreakdown({ result }: { result: GradingResult }) {
         </div>
       </div>
 
+      {/* Focus Here First — primary improvement */}
+      {result.primary_improvement && (
+        <div className="bg-amber-500/10 border border-amber-500/40 rounded-xl p-5">
+          <h3 className="text-amber-400 font-semibold text-sm uppercase tracking-widest mb-2">
+            Focus Here First
+          </h3>
+          <p className="text-amber-100/80 text-sm leading-relaxed">
+            {result.primary_improvement}
+          </p>
+        </div>
+      )}
+
       {/* Overall feedback */}
       {result.overall_feedback && (
         <div className="bg-[#120020] border border-purple-500/20 rounded-xl p-5">

--- a/frontend/types/grading.ts
+++ b/frontend/types/grading.ts
@@ -30,6 +30,7 @@ export interface GradingResult {
   total_awarded: number;
   sections: SectionScore[];
   overall_feedback: string;
+  primary_improvement: string;
   penalties?: PenaltyCheck[];
 }
 


### PR DESCRIPTION
## Summary
- Adds a `primary_improvement` field to the grading schema, Pydantic model, and TypeScript types — the LLM now returns one concrete, high-impact fix the student should make
- Adds `PRIMARY IMPROVEMENT` and `SECTION FEEDBACK REQUIREMENT` instruction blocks to the system prompt, directing the LLM to name specific sections, reference actual content from the report, and avoid generic advice
- Renders a "Focus Here First" amber callout block in `ScoreBreakdown.tsx` between the score card and overall feedback

## Test plan
- [ ] Submit a report and confirm the result JSON contains a non-empty `primary_improvement` field
- [ ] Confirm section feedback references specific content from the submitted report (not boilerplate)
- [ ] Confirm the amber "Focus Here First" block renders between the score card and overall feedback on the results page