### PR TITLE
Add Entrepreneurship cluster with per-event rubric architecture

### DIFF
--- a/backend/app/services/rubric_service.py
+++ b/backend/app/services/rubric_service.py
@@ -5,18 +5,18 @@ from typing import List, Optional
 
 from sqlalchemy.orm import Session
 
-from ..events_data import get_cluster_for_code
+from ..events_data import get_rubric_name_for_code
 from ..models import Rubric
 
 logger = logging.getLogger(__name__)
 
 
 def get_rubric_by_event_code(db: Session, event_code: str) -> Optional[Rubric]:
-    """Get a rubric by specific event code, resolving through its cluster."""
-    cluster = get_cluster_for_code(event_code)
-    if not cluster:
+    """Get rubric by event code, checking event-level rubric_name override first."""
+    rubric_name = get_rubric_name_for_code(event_code)
+    if not rubric_name:
         return None
-    return get_rubric_by_event(db, cluster["cluster_name"])
+    return get_rubric_by_event(db, rubric_name)
 
 
 def get_rubric_by_event(db: Session, event_name: str) -> Optional[Rubric]:

--- a/backend/rubrics/business_growth_plan.json
+++ b/backend/rubrics/business_growth_plan.json
@@ -1,0 +1,110 @@
+{
+  "event": "Business Growth Plan",
+  "total_points": 60,
+  "required_outline": {
+    "I. Executive Summary": "One- to three-page description of the plan",
+    "II. Introduction": {
+      "A. Type of business": "Type of business owned and operated and description of current business operations",
+      "B. Products and/or Services": "Description of the products and/or services offered",
+      "C. Unique Characteristics": "Unique characteristics of the business"
+    },
+    "III. SWOT Analysis": {
+      "A. Strengths": "Strengths of the business",
+      "B. Weaknesses": "Weaknesses of the business",
+      "C. Opportunities": "Opportunities available for the business",
+      "D. Threats": "Threats to the business"
+    },
+    "IV. Five Year Plan to Grow and Expand the Business": {
+      "A. Expansion Opportunities": "Specific opportunities identified for growth",
+      "B. New Market Analysis": "Analysis of new markets being targeted",
+      "C. Marketing Plan": "Plan to reach new markets"
+    },
+    "V. Financing Plan": {
+      "A. Current Financial Situation": "Current financial situation of the business",
+      "B. Fixed Overhead and Cost of Operations": "Fixed overhead and cost of operations",
+      "C. Capital Needed": "Capital needed for expansion opportunities",
+      "D. Time to Achieve Profitability": "Projected timeline to achieve profitability"
+    },
+    "VI. Conclusion": "Summary of key points",
+    "VII. Proof of Ownership (un-numbered pages)": "Documentation to verify student ownership/operation — does not count toward 20-page limit"
+  },
+  "sections": [
+    {
+      "name": "Executive Summary",
+      "max_points": 10,
+      "description": "One- to three-page description of the plan",
+      "scoring_guide": {
+        "0-3": "Little/No Value",
+        "4-6": "Below Expectations",
+        "7-8": "Meets Expectations",
+        "9-10": "Exceeds Expectations"
+      }
+    },
+    {
+      "name": "Introduction",
+      "max_points": 9,
+      "description": "Type of business owned and operated, description of products/services offered, and unique characteristics of the business (3 points each)",
+      "scoring_guide": {
+        "0-2": "Little/No Value",
+        "3-5": "Below Expectations",
+        "6-7": "Meets Expectations",
+        "8-9": "Exceeds Expectations"
+      }
+    },
+    {
+      "name": "SWOT Analysis",
+      "max_points": 12,
+      "description": "Strengths, weaknesses, opportunities, and threats of the business (3 points each)",
+      "scoring_guide": {
+        "0-3": "Little/No Value",
+        "4-6": "Below Expectations",
+        "7-9": "Meets Expectations",
+        "10-12": "Exceeds Expectations"
+      }
+    },
+    {
+      "name": "Five Year Plan to Grow and Expand the Business",
+      "max_points": 11,
+      "description": "Expansion opportunities (4 pts), new market analysis (4 pts), and marketing plan (3 pts)",
+      "scoring_guide": {
+        "0-2": "Little/No Value",
+        "3-5": "Below Expectations",
+        "6-8": "Meets Expectations",
+        "9-11": "Exceeds Expectations"
+      }
+    },
+    {
+      "name": "Financing Plan",
+      "max_points": 12,
+      "description": "Current financial situation, fixed overhead and cost of operations, capital needed for expansion, and time to achieve profitability (3 points each)",
+      "scoring_guide": {
+        "0-3": "Little/No Value",
+        "4-6": "Below Expectations",
+        "7-9": "Meets Expectations",
+        "10-12": "Exceeds Expectations"
+      }
+    },
+    {
+      "name": "Conclusion",
+      "max_points": 3,
+      "description": "Summary of key points",
+      "scoring_guide": {
+        "0": "Little/No Value",
+        "1": "Below Expectations",
+        "2": "Meets Expectations",
+        "3": "Exceeds Expectations"
+      }
+    },
+    {
+      "name": "Appearance and Word Usage",
+      "max_points": 3,
+      "description": "Professional layout, neatness, proper grammar, spelling and word usage",
+      "scoring_guide": {
+        "0": "Little/No Value",
+        "1": "Below Expectations",
+        "2": "Meets Expectations",
+        "3": "Exceeds Expectations"
+      }
+    }
+  ]
+}

--- a/backend/rubrics/franchise_business_plan.json
+++ b/backend/rubrics/franchise_business_plan.json
@@ -1,0 +1,140 @@
+{
+  "event": "Franchise Business Plan",
+  "total_points": 60,
+  "required_outline": {
+    "I. Executive Summary": "One- to three-page description of the business model",
+    "II. Business History, Background and Objective": "Description of the company, objectives, company successes and challenges, and requirements to franchise",
+    "III. Business Environment": "Description of how environmental factors may affect the business",
+    "IV. Products and/or Services": "List of and descriptions of the products and/or services offered",
+    "V. Present Market": "Description of the present market, growth potential and pricing policy",
+    "VI. Competition": "List of the company's primary competitors in the market and identification of their strengths and weaknesses",
+    "VII. Marketing Plan": "Description of existing and future marketing techniques and strategies",
+    "VIII. Management and Organization": "Description of the management team, management team development plan, succession plan, and the need for additional personnel",
+    "IX. Business Resources": "Major operating equipment, major suppliers, payment terms, outside resources, quality control procedures, availability of skilled labor, training needs, number of full-time and part-time employees, and organizational chart",
+    "X. Financial Plan and Data": "Sales and profit trends, strategy and timing for obtaining capital, two-year projected operating statement, one-year projected cash flow statement",
+    "XI. Conclusion": "Specific request for financing, summary of key points supporting the financial request"
+  },
+  "sections": [
+    {
+      "name": "Executive Summary",
+      "max_points": 10,
+      "description": "One- to three-page description of the business model",
+      "scoring_guide": {
+        "0-3": "Little/No Value",
+        "4-6": "Below Expectations",
+        "7-8": "Meets Expectations",
+        "9-10": "Exceeds Expectations"
+      }
+    },
+    {
+      "name": "Business History, Background and Objective",
+      "max_points": 5,
+      "description": "Description of the company, objectives, company successes and challenges, and requirements to franchise",
+      "scoring_guide": {
+        "0-1": "Little/No Value",
+        "2-3": "Below Expectations",
+        "4": "Meets Expectations",
+        "5": "Exceeds Expectations"
+      }
+    },
+    {
+      "name": "Business Environment",
+      "max_points": 5,
+      "description": "Description of how environmental factors may affect the business",
+      "scoring_guide": {
+        "0-1": "Little/No Value",
+        "2-3": "Below Expectations",
+        "4": "Meets Expectations",
+        "5": "Exceeds Expectations"
+      }
+    },
+    {
+      "name": "Products and/or Services",
+      "max_points": 5,
+      "description": "List of and descriptions of the products and/or services offered",
+      "scoring_guide": {
+        "0-1": "Little/No Value",
+        "2-3": "Below Expectations",
+        "4": "Meets Expectations",
+        "5": "Exceeds Expectations"
+      }
+    },
+    {
+      "name": "Present Market",
+      "max_points": 5,
+      "description": "Description of the present market, growth potential and pricing policy",
+      "scoring_guide": {
+        "0-1": "Little/No Value",
+        "2-3": "Below Expectations",
+        "4": "Meets Expectations",
+        "5": "Exceeds Expectations"
+      }
+    },
+    {
+      "name": "Competition",
+      "max_points": 5,
+      "description": "List of the company's primary competitors in the market and identification of their strengths and weaknesses",
+      "scoring_guide": {
+        "0-1": "Little/No Value",
+        "2-3": "Below Expectations",
+        "4": "Meets Expectations",
+        "5": "Exceeds Expectations"
+      }
+    },
+    {
+      "name": "Marketing Plan",
+      "max_points": 5,
+      "description": "Description of existing and future marketing techniques and strategies",
+      "scoring_guide": {
+        "0-1": "Little/No Value",
+        "2-3": "Below Expectations",
+        "4": "Meets Expectations",
+        "5": "Exceeds Expectations"
+      }
+    },
+    {
+      "name": "Management and Organization",
+      "max_points": 5,
+      "description": "Description of the management team, development plan, succession plan, and need for additional personnel",
+      "scoring_guide": {
+        "0-1": "Little/No Value",
+        "2-3": "Below Expectations",
+        "4": "Meets Expectations",
+        "5": "Exceeds Expectations"
+      }
+    },
+    {
+      "name": "Business Resources",
+      "max_points": 5,
+      "description": "Major operating equipment, suppliers, payment terms, outside resources, quality control, skilled labor availability, training needs, employee counts, and organizational chart",
+      "scoring_guide": {
+        "0-1": "Little/No Value",
+        "2-3": "Below Expectations",
+        "4": "Meets Expectations",
+        "5": "Exceeds Expectations"
+      }
+    },
+    {
+      "name": "Financial Plan and Data",
+      "max_points": 5,
+      "description": "Sales and profit trends, capital acquisition strategy and timing, two-year projected operating statement, one-year projected cash flow statement",
+      "scoring_guide": {
+        "0-1": "Little/No Value",
+        "2-3": "Below Expectations",
+        "4": "Meets Expectations",
+        "5": "Exceeds Expectations"
+      }
+    },
+    {
+      "name": "Conclusion",
+      "max_points": 5,
+      "description": "Specific request for financing and summary of key points supporting the financial request",
+      "scoring_guide": {
+        "0-1": "Little/No Value",
+        "2-3": "Below Expectations",
+        "4": "Meets Expectations",
+        "5": "Exceeds Expectations"
+      }
+    }
+  ]
+}

--- a/backend/rubrics/independent_business_plan.json
+++ b/backend/rubrics/independent_business_plan.json
@@ -1,0 +1,152 @@
+{
+  "event": "Independent Business Plan",
+  "total_points": 60,
+  "required_outline": {
+    "I. Executive Summary": "One- to three-page description of the business model",
+    "II. Problem": "Description of the top problems the product/service is addressing",
+    "III. Customer Segments": "Description of target customers",
+    "IV. Unique Value Proposition": "Single, clear, compelling message that states the unique value proposition",
+    "V. Solution": "Description of the top features of the product/service that solve the problem",
+    "VI. Channels": "Descriptions of the pathways to customers",
+    "VII. Revenue Stream": "Description of the revenue model and lifetime values",
+    "VIII. Cost Structure": "Explanation of customer acquisition costs, distribution costs, human resources costs and additional costs",
+    "IX. Detailed Financials": "Projected income and expenses and proposed plan to meet capital needs",
+    "X. Key Metrics": "Explanation of the key activities that must be measured",
+    "XI. Competitive Advantage": "Explanation of why the product/service cannot be easily copied or bought",
+    "XII. Conclusion": "Specific request for financing, summary of key points supporting the financial request"
+  },
+  "sections": [
+    {
+      "name": "Executive Summary",
+      "max_points": 10,
+      "description": "One- to three-page description of the business model",
+      "scoring_guide": {
+        "0-3": "Little/No Value",
+        "4-6": "Below Expectations",
+        "7-8": "Meets Expectations",
+        "9-10": "Exceeds Expectations"
+      }
+    },
+    {
+      "name": "Problem",
+      "max_points": 4,
+      "description": "Description of the top problems the product/service is addressing",
+      "scoring_guide": {
+        "0-1": "Little/No Value",
+        "2": "Below Expectations",
+        "3": "Meets Expectations",
+        "4": "Exceeds Expectations"
+      }
+    },
+    {
+      "name": "Customer Segments",
+      "max_points": 4,
+      "description": "Description of target customers",
+      "scoring_guide": {
+        "0-1": "Little/No Value",
+        "2": "Below Expectations",
+        "3": "Meets Expectations",
+        "4": "Exceeds Expectations"
+      }
+    },
+    {
+      "name": "Unique Value Proposition",
+      "max_points": 4,
+      "description": "Single, clear, compelling message that states the unique value proposition",
+      "scoring_guide": {
+        "0-1": "Little/No Value",
+        "2": "Below Expectations",
+        "3": "Meets Expectations",
+        "4": "Exceeds Expectations"
+      }
+    },
+    {
+      "name": "Solution",
+      "max_points": 4,
+      "description": "Description of the top features of the product/service that solve the problem",
+      "scoring_guide": {
+        "0-1": "Little/No Value",
+        "2": "Below Expectations",
+        "3": "Meets Expectations",
+        "4": "Exceeds Expectations"
+      }
+    },
+    {
+      "name": "Channels",
+      "max_points": 4,
+      "description": "Descriptions of the pathways to customers",
+      "scoring_guide": {
+        "0-1": "Little/No Value",
+        "2": "Below Expectations",
+        "3": "Meets Expectations",
+        "4": "Exceeds Expectations"
+      }
+    },
+    {
+      "name": "Revenue Stream",
+      "max_points": 4,
+      "description": "Description of the revenue model and lifetime values",
+      "scoring_guide": {
+        "0-1": "Little/No Value",
+        "2": "Below Expectations",
+        "3": "Meets Expectations",
+        "4": "Exceeds Expectations"
+      }
+    },
+    {
+      "name": "Cost Structure",
+      "max_points": 4,
+      "description": "Explanation of customer acquisition costs, distribution costs, human resources costs, and any additional costs",
+      "scoring_guide": {
+        "0-1": "Little/No Value",
+        "2": "Below Expectations",
+        "3": "Meets Expectations",
+        "4": "Exceeds Expectations"
+      }
+    },
+    {
+      "name": "Detailed Financials",
+      "max_points": 10,
+      "description": "Projected income and expenses and proposed plan to meet capital needs",
+      "scoring_guide": {
+        "0-3": "Little/No Value",
+        "4-6": "Below Expectations",
+        "7-8": "Meets Expectations",
+        "9-10": "Exceeds Expectations"
+      }
+    },
+    {
+      "name": "Key Metrics",
+      "max_points": 4,
+      "description": "Explanation of the key activities that must be measured",
+      "scoring_guide": {
+        "0-1": "Little/No Value",
+        "2": "Below Expectations",
+        "3": "Meets Expectations",
+        "4": "Exceeds Expectations"
+      }
+    },
+    {
+      "name": "Competitive Advantage",
+      "max_points": 4,
+      "description": "Explanation of why the product/service cannot be easily copied or bought",
+      "scoring_guide": {
+        "0-1": "Little/No Value",
+        "2": "Below Expectations",
+        "3": "Meets Expectations",
+        "4": "Exceeds Expectations"
+      }
+    },
+    {
+      "name": "Conclusion",
+      "max_points": 4,
+      "description": "Specific request for financing and summary of key points supporting the financial request",
+      "scoring_guide": {
+        "0-1": "Little/No Value",
+        "2": "Below Expectations",
+        "3": "Meets Expectations",
+        "4": "Exceeds Expectations"
+      }
+    }
+  ]
+}

--- a/backend/rubrics/international_business_plan.json
+++ b/backend/rubrics/international_business_plan.json
@@ -1,0 +1,164 @@
+{
+  "event": "International Business Plan",
+  "total_points": 60,
+  "required_outline": {
+    "I. Executive Summary": "One- to three-page description of the business model",
+    "II. Analysis of the International Business Situation": "Economic, political and legal analysis; trade area and cultural analysis",
+    "III. Problem": "Description of the problems the product/service is addressing",
+    "IV. Customer Segments": "Description of target customers",
+    "V. Unique Value Proposition": "Single, clear, compelling message that states the unique value proposition",
+    "VI. Solution": "Description of the top features of the product/service that solve the problem",
+    "VII. Channels": "Descriptions of the pathways to customers",
+    "VIII. Revenue Stream": "Description of the revenue model and lifetime values",
+    "IX. Cost Structure": "Explanation of customer acquisition costs, distribution costs, human resources costs and additional costs",
+    "X. Detailed Financials": "Projected income and expenses and proposed plan to meet capital needs",
+    "XI. Key Metrics": "Explanation of the key activities that must be measured",
+    "XII. Competitive Advantage": "Explanation of why the product/service cannot be easily copied or bought",
+    "XIII. Conclusion": "Specific request for financing, summary of key points supporting the financial request"
+  },
+  "sections": [
+    {
+      "name": "Executive Summary",
+      "max_points": 10,
+      "description": "One- to three-page description of the business model",
+      "scoring_guide": {
+        "0-3": "Little/No Value",
+        "4-6": "Below Expectations",
+        "7-8": "Meets Expectations",
+        "9-10": "Exceeds Expectations"
+      }
+    },
+    {
+      "name": "Analysis of the International Business Situation",
+      "max_points": 4,
+      "description": "Description of economic, political and legal analysis; trade area and cultural analysis",
+      "scoring_guide": {
+        "0-1": "Little/No Value",
+        "2": "Below Expectations",
+        "3": "Meets Expectations",
+        "4": "Exceeds Expectations"
+      }
+    },
+    {
+      "name": "Problem",
+      "max_points": 4,
+      "description": "Description of the problems the product/service is addressing in the international context",
+      "scoring_guide": {
+        "0-1": "Little/No Value",
+        "2": "Below Expectations",
+        "3": "Meets Expectations",
+        "4": "Exceeds Expectations"
+      }
+    },
+    {
+      "name": "Customer Segments",
+      "max_points": 4,
+      "description": "Description of target customers",
+      "scoring_guide": {
+        "0-1": "Little/No Value",
+        "2": "Below Expectations",
+        "3": "Meets Expectations",
+        "4": "Exceeds Expectations"
+      }
+    },
+    {
+      "name": "Unique Value Proposition",
+      "max_points": 4,
+      "description": "Single, clear, compelling message that states the unique value proposition",
+      "scoring_guide": {
+        "0-1": "Little/No Value",
+        "2": "Below Expectations",
+        "3": "Meets Expectations",
+        "4": "Exceeds Expectations"
+      }
+    },
+    {
+      "name": "Solution",
+      "max_points": 4,
+      "description": "Description of the top features of the product/service that solve the problem",
+      "scoring_guide": {
+        "0-1": "Little/No Value",
+        "2": "Below Expectations",
+        "3": "Meets Expectations",
+        "4": "Exceeds Expectations"
+      }
+    },
+    {
+      "name": "Channels",
+      "max_points": 4,
+      "description": "Descriptions of the pathways to customers",
+      "scoring_guide": {
+        "0-1": "Little/No Value",
+        "2": "Below Expectations",
+        "3": "Meets Expectations",
+        "4": "Exceeds Expectations"
+      }
+    },
+    {
+      "name": "Revenue Stream",
+      "max_points": 4,
+      "description": "Description of the revenue model and lifetime values",
+      "scoring_guide": {
+        "0-1": "Little/No Value",
+        "2": "Below Expectations",
+        "3": "Meets Expectations",
+        "4": "Exceeds Expectations"
+      }
+    },
+    {
+      "name": "Cost Structure",
+      "max_points": 5,
+      "description": "Explanation of customer acquisition costs, distribution costs, human resources costs, and any additional costs",
+      "scoring_guide": {
+        "0-1": "Little/No Value",
+        "2-3": "Below Expectations",
+        "4": "Meets Expectations",
+        "5": "Exceeds Expectations"
+      }
+    },
+    {
+      "name": "Detailed Financials",
+      "max_points": 5,
+      "description": "Projected income and expenses and proposed plan to meet capital needs",
+      "scoring_guide": {
+        "0-1": "Little/No Value",
+        "2-3": "Below Expectations",
+        "4": "Meets Expectations",
+        "5": "Exceeds Expectations"
+      }
+    },
+    {
+      "name": "Key Metrics",
+      "max_points": 4,
+      "description": "Explanation of the key activities that must be measured",
+      "scoring_guide": {
+        "0-1": "Little/No Value",
+        "2": "Below Expectations",
+        "3": "Meets Expectations",
+        "4": "Exceeds Expectations"
+      }
+    },
+    {
+      "name": "Competitive Advantage",
+      "max_points": 4,
+      "description": "Explanation of why the product/service cannot be easily copied or bought",
+      "scoring_guide": {
+        "0-1": "Little/No Value",
+        "2": "Below Expectations",
+        "3": "Meets Expectations",
+        "4": "Exceeds Expectations"
+      }
+    },
+    {
+      "name": "Conclusion",
+      "max_points": 4,
+      "description": "Specific request for financing and summary of key points supporting the financial request",
+      "scoring_guide": {
+        "0-1": "Little/No Value",
+        "2": "Below Expectations",
+        "3": "Meets Expectations",
+        "4": "Exceeds Expectations"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Introduces an optional `rubric_name` field on `EventInfo` so any event can override the cluster-level rubric lookup — backwards-compatible, existing clusters unchanged
- Adds `get_rubric_name_for_code()` helper in `events_data.py` (event-level override → cluster fallback)
- Wires up the full Entrepreneurship cluster with 4 events: EBG, EFB, EIB, IBP — each with its own 60-point rubric JSON
- Updates `rubric_service.get_rubric_by_event_code()` and the upload endpoint in `main.py` to use the new helper
- Adds `_cluster_is_available()` to `list_events` so clusters whose events have per-event rubrics still appear in the dropdown

## Rubrics added
| Code | Event | Sections |
|------|-------|----------|
| EBG | Business Growth Plan | 7 (Executive Summary, Introduction, SWOT, 5-Year Plan, Financing Plan, Conclusion, Appearance) |
| EFB | Franchise Business Plan | 11 (Executive Summary + 10 content sections) |
| EIB | Independent Business Plan | 12 (Executive Summary + 11 lean-canvas sections) |
| IBP | International Business Plan | 13 (Executive Summary + international situation analysis + 11 sections) |

## EBG ownership proof
No code changes to `pdf_service.py`. The 25-page global limit stays unchanged. EBG's ownership proof requirement is surfaced entirely via the event `description` field, which instructs the LLM to flag missing ownership evidence in `overall_feedback`.

## Test plan
- [x] Restart backend → confirm `_seed_rubrics()` logs all 4 new rubrics auto-seeded
- [ ] `GET /api/events` → Entrepreneurship Events cluster appears with 4 events
- [ ] Upload a PDF with each of EBG / EFB / EIB / IBP → job creates and grades successfully with event-specific sections
- [x] Upload with BOR or PMBS → existing behavior unchanged (regression check)
- [x] DB has 6 rubrics total after seeding