### PR TITLE
Route API calls through Next.js proxy for LAN and remote access

### DIFF
--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1,6 +1,6 @@
 import { ClusterEvents, JobStatus, UploadResponse } from "@/types/grading";
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
+const API_URL = "";
 
 export async function getEvents(): Promise<ClusterEvents[]> {
   const res = await fetch(`${API_URL}/api/events`);

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,7 +1,14 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  async rewrites() {
+    return [
+      {
+        source: "/api/:path*",
+        destination: `${process.env.BACKEND_URL || "http://localhost:8000"}/api/:path*`,
+      },
+    ];
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- Removes `NEXT_PUBLIC_API_URL` (hardcoded `localhost:8000` baked into client JS) — this was the reason API calls failed on any device other than your Mac
- Adds a Next.js rewrite in `next.config.ts` that proxies `/api/*` server-side to `BACKEND_URL` (defaults to `http://localhost:8000`)
- `lib/api.ts` now uses a relative URL (`""`) — all fetch calls become `/api/events`, `/api/upload`, etc., hitting the rewrite

## How it works
Browser calls `/api/events` → Next.js server receives it → proxies to `localhost:8000/api/events` → returns response. The backend is never exposed directly.

## What this enables
- **LAN access:** share the Network URL (`http://192.168.x.x:3001`) — works immediately, no other changes
- **Remote access:** run `ngrok http 3001`, share the ngrok URL — backend calls are handled server-side, no env var changes needed per session
- **Future cloud deploy:** set `BACKEND_URL=https://your-api.railway.app` in Vercel dashboard — zero code changes required

## Test plan
- [ ] Restart frontend, confirm `http://localhost:3001` still works normally
- [ ] Open the Network URL on a phone (same Wi-Fi) — events load, grading completes
- [ ] Run `ngrok http 3001`, open the ngrok URL on a separate device — full grading flow works end-to-end