### PR TITLE
Fix TailwindCSS module resolution error in dev server

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "ai-rubric-evaluator",
+  "version": "1.0.0",
+  "private": true
+}


### PR DESCRIPTION
## Summary
- Adds a minimal `package.json` at the project root (`/ai-rubric-evaluator/`)
- Fixes the `Can't resolve 'tailwindcss'` error that was crashing the frontend dev server

## Root Cause
Node.js module resolver walks up the directory tree to find the nearest `package.json`. With no `package.json` at the project root, it climbed all the way up to `/Users/ParthDoshi/package.json` — an unrelated project containing only googleapis/nodemailer. Webpack then tried to resolve `tailwindcss` from that directory's `node_modules`, which doesn't have it.

## Test Plan
- [ ] Stop any running dev server
- [ ] From `frontend/`, run `npm run dev`
- [ ] Confirm server starts without TailwindCSS resolve errors
- [ ] Visit `http://localhost:3000` and confirm styles load correctly