### PR TITLE
feat: upgrade admin dashboard with analytics and charts

### DIFF
--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -10,7 +10,7 @@ from sqlalchemy.orm import Session
 from ..auth import require_admin
 from ..database import get_db
 from ..models import Job, User
-from ..schemas import AdminStats, AdminSubmissionRow, AdminUserRow
+from ..schemas import AdminAnalytics, AdminStats, AdminSubmissionRow, AdminUserRow, DailyDataPoint
 
 router = APIRouter(prefix="/api/admin", tags=["admin"])
 
@@ -25,12 +25,45 @@ def get_stats(
     total_submissions = db.query(func.count(Job.id)).scalar() or 0
 
     today_start = datetime.utcnow().replace(hour=0, minute=0, second=0, microsecond=0)
+    week_start = today_start - timedelta(days=today_start.weekday())
+
     submissions_today = (
         db.query(func.count(Job.id))
         .filter(Job.created_at >= today_start)
         .scalar()
         or 0
     )
+
+    submissions_this_week = (
+        db.query(func.count(Job.id))
+        .filter(Job.created_at >= week_start)
+        .scalar()
+        or 0
+    )
+
+    unique_ips = (
+        db.query(func.count(func.distinct(Job.ip_address)))
+        .filter(Job.ip_address.isnot(None))
+        .scalar()
+        or 0
+    )
+
+    anonymous_submissions = (
+        db.query(func.count(Job.id))
+        .filter(Job.user_id.is_(None))
+        .scalar()
+        or 0
+    )
+
+    authenticated_submissions = total_submissions - anonymous_submissions
+
+    completed_jobs = (
+        db.query(func.count(Job.id))
+        .filter(Job.status == "complete")
+        .scalar()
+        or 0
+    )
+    completion_rate = round((completed_jobs / total_submissions * 100) if total_submissions > 0 else 0.0, 1)
 
     top_events_rows = (
         db.query(Job.event_code, func.count(Job.id).label("count"))
@@ -46,7 +79,83 @@ def get_stats(
         total_users=total_users,
         total_submissions=total_submissions,
         submissions_today=submissions_today,
+        submissions_this_week=submissions_this_week,
+        unique_ips=unique_ips,
+        anonymous_submissions=anonymous_submissions,
+        authenticated_submissions=authenticated_submissions,
+        completion_rate=completion_rate,
         top_events=top_events,
+    )
+
+
+@router.get("/analytics", response_model=AdminAnalytics)
+def get_analytics(
+    db: Session = Depends(get_db),
+    _admin: User = Depends(require_admin),
+):
+    """Time-series analytics for the last 30 days."""
+    today = datetime.utcnow().replace(hour=0, minute=0, second=0, microsecond=0)
+    start = today - timedelta(days=29)
+
+    # Build a complete date list for the last 30 days
+    dates = [(start + timedelta(days=i)).strftime("%Y-%m-%d") for i in range(30)]
+
+    # Signups per day
+    signup_rows = (
+        db.query(
+            func.strftime("%Y-%m-%d", User.created_at).label("day"),
+            func.count(User.id).label("cnt"),
+        )
+        .filter(User.created_at >= start)
+        .group_by("day")
+        .all()
+    )
+    signup_map = {row.day: row.cnt for row in signup_rows}
+
+    # Submissions per day (all)
+    sub_rows = (
+        db.query(
+            func.strftime("%Y-%m-%d", Job.created_at).label("day"),
+            func.count(Job.id).label("cnt"),
+        )
+        .filter(Job.created_at >= start)
+        .group_by("day")
+        .all()
+    )
+    sub_map = {row.day: row.cnt for row in sub_rows}
+
+    # Anonymous submissions per day (user_id IS NULL)
+    anon_rows = (
+        db.query(
+            func.strftime("%Y-%m-%d", Job.created_at).label("day"),
+            func.count(Job.id).label("cnt"),
+        )
+        .filter(Job.created_at >= start, Job.user_id.is_(None))
+        .group_by("day")
+        .all()
+    )
+    anon_map = {row.day: row.cnt for row in anon_rows}
+
+    # Auth submissions per day
+    auth_rows = (
+        db.query(
+            func.strftime("%Y-%m-%d", Job.created_at).label("day"),
+            func.count(Job.id).label("cnt"),
+        )
+        .filter(Job.created_at >= start, Job.user_id.isnot(None))
+        .group_by("day")
+        .all()
+    )
+    auth_map = {row.day: row.cnt for row in auth_rows}
+
+    def build_series(mapping: dict) -> List[DailyDataPoint]:
+        return [DailyDataPoint(date=d, value=mapping.get(d, 0)) for d in dates]
+
+    return AdminAnalytics(
+        signups_30d=build_series(signup_map),
+        submissions_30d=build_series(sub_map),
+        anon_submissions_30d=build_series(anon_map),
+        auth_submissions_30d=build_series(auth_map),
     )
 
 

--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -100,53 +100,55 @@ def get_analytics(
     # Build a complete date list for the last 30 days
     dates = [(start + timedelta(days=i)).strftime("%Y-%m-%d") for i in range(30)]
 
+    from sqlalchemy import cast, Date
+
     # Signups per day
     signup_rows = (
         db.query(
-            func.strftime("%Y-%m-%d", User.created_at).label("day"),
+            cast(User.created_at, Date).label("day"),
             func.count(User.id).label("cnt"),
         )
         .filter(User.created_at >= start)
-        .group_by("day")
+        .group_by(cast(User.created_at, Date))
         .all()
     )
-    signup_map = {row.day: row.cnt for row in signup_rows}
+    signup_map = {row.day.strftime("%Y-%m-%d"): row.cnt for row in signup_rows}
 
     # Submissions per day (all)
     sub_rows = (
         db.query(
-            func.strftime("%Y-%m-%d", Job.created_at).label("day"),
+            cast(Job.created_at, Date).label("day"),
             func.count(Job.id).label("cnt"),
         )
         .filter(Job.created_at >= start)
-        .group_by("day")
+        .group_by(cast(Job.created_at, Date))
         .all()
     )
-    sub_map = {row.day: row.cnt for row in sub_rows}
+    sub_map = {row.day.strftime("%Y-%m-%d"): row.cnt for row in sub_rows}
 
     # Anonymous submissions per day (user_id IS NULL)
     anon_rows = (
         db.query(
-            func.strftime("%Y-%m-%d", Job.created_at).label("day"),
+            cast(Job.created_at, Date).label("day"),
             func.count(Job.id).label("cnt"),
         )
         .filter(Job.created_at >= start, Job.user_id.is_(None))
-        .group_by("day")
+        .group_by(cast(Job.created_at, Date))
         .all()
     )
-    anon_map = {row.day: row.cnt for row in anon_rows}
+    anon_map = {row.day.strftime("%Y-%m-%d"): row.cnt for row in anon_rows}
 
     # Auth submissions per day
     auth_rows = (
         db.query(
-            func.strftime("%Y-%m-%d", Job.created_at).label("day"),
+            cast(Job.created_at, Date).label("day"),
             func.count(Job.id).label("cnt"),
         )
         .filter(Job.created_at >= start, Job.user_id.isnot(None))
-        .group_by("day")
+        .group_by(cast(Job.created_at, Date))
         .all()
     )
-    auth_map = {row.day: row.cnt for row in auth_rows}
+    auth_map = {row.day.strftime("%Y-%m-%d"): row.cnt for row in auth_rows}
 
     def build_series(mapping: dict) -> List[DailyDataPoint]:
         return [DailyDataPoint(date=d, value=mapping.get(d, 0)) for d in dates]

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -99,4 +99,21 @@ class AdminStats(BaseModel):
     total_users: int
     total_submissions: int
     submissions_today: int
+    submissions_this_week: int
+    unique_ips: int
+    anonymous_submissions: int
+    authenticated_submissions: int
+    completion_rate: float  # 0-100
     top_events: List[dict]  # [{"event_code": str, "count": int}]
+
+
+class DailyDataPoint(BaseModel):
+    date: str  # "YYYY-MM-DD"
+    value: int
+
+
+class AdminAnalytics(BaseModel):
+    signups_30d: List[DailyDataPoint]
+    submissions_30d: List[DailyDataPoint]
+    anon_submissions_30d: List[DailyDataPoint]
+    auth_submissions_30d: List[DailyDataPoint]

--- a/frontend/app/admin/page.tsx
+++ b/frontend/app/admin/page.tsx
@@ -5,15 +5,43 @@ import { useSession, signIn } from "next-auth/react";
 import { useRouter } from "next/navigation";
 import ScorelyLogo from "@/components/ScorelyLogo";
 import AuthButton from "@/components/AuthButton";
-import { getAdminStats, getAdminUsers, getAdminUserSubmissions } from "@/lib/api";
+import { getAdminStats, getAdminUsers, getAdminUserSubmissions, getAdminAnalytics } from "@/lib/api";
+import {
+  LineChart,
+  Line,
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+  Legend,
+  Cell,
+} from "recharts";
 
 const ADMIN_EMAIL = process.env.NEXT_PUBLIC_ADMIN_EMAIL;
+
+// ─── Types ────────────────────────────────────────────────────────────────────
 
 interface Stats {
   total_users: number;
   total_submissions: number;
   submissions_today: number;
+  submissions_this_week: number;
+  unique_ips: number;
+  anonymous_submissions: number;
+  authenticated_submissions: number;
+  completion_rate: number;
   top_events: { event_code: string; count: number }[];
+}
+
+interface DailyPoint { date: string; value: number }
+
+interface Analytics {
+  signups_30d: DailyPoint[];
+  submissions_30d: DailyPoint[];
+  anon_submissions_30d: DailyPoint[];
+  auth_submissions_30d: DailyPoint[];
 }
 
 interface AdminUser {
@@ -35,6 +63,8 @@ interface Submission {
   created_at: string;
 }
 
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
 function formatDate(iso: string) {
   return new Date(iso).toLocaleDateString("en-US", {
     month: "short",
@@ -43,10 +73,49 @@ function formatDate(iso: string) {
   });
 }
 
+function shortDate(iso: string) {
+  const d = new Date(iso + "T00:00:00");
+  return d.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+}
+
+// ─── Sub-components ───────────────────────────────────────────────────────────
+
+function StatCard({
+  label,
+  value,
+  sub,
+  accent,
+}: {
+  label: string;
+  value: string | number;
+  sub?: string;
+  accent?: string;
+}) {
+  return (
+    <div className="bg-[#060F1A] border border-[#1E3A5F] rounded-xl px-5 py-4 flex flex-col gap-1">
+      <p className="text-[#64748B] text-xs font-medium uppercase tracking-widest">{label}</p>
+      <p className={`text-3xl font-bold ${accent ?? "text-[#E2E8F0]"}`}>
+        {typeof value === "number" ? value.toLocaleString() : value}
+      </p>
+      {sub && <p className="text-[#64748B] text-xs">{sub}</p>}
+    </div>
+  );
+}
+
+function SectionHeader({ children }: { children: React.ReactNode }) {
+  return (
+    <h2 className="text-[#94A3B8] text-xs font-semibold uppercase tracking-widest mb-4">
+      {children}
+    </h2>
+  );
+}
+
 function ScoreBar({ awarded, possible }: { awarded?: number; possible?: number }) {
-  if (awarded == null || possible == null || possible === 0) return <span className="text-[#64748B] text-xs">—</span>;
+  if (awarded == null || possible == null || possible === 0)
+    return <span className="text-[#64748B] text-xs">—</span>;
   const pct = Math.round((awarded / possible) * 100);
-  const color = pct >= 80 ? "#22C55E" : pct >= 60 ? "#EAB308" : pct >= 40 ? "#F97316" : "#EF4444";
+  const color =
+    pct >= 80 ? "#22C55E" : pct >= 60 ? "#EAB308" : pct >= 40 ? "#F97316" : "#EF4444";
   return (
     <span className="text-xs font-semibold" style={{ color }}>
       {pct}% ({awarded}/{possible})
@@ -54,10 +123,39 @@ function ScoreBar({ awarded, possible }: { awarded?: number; possible?: number }
   );
 }
 
+function StatusBadge({ status }: { status: string }) {
+  const colors: Record<string, string> = {
+    complete: "text-[#22C55E] bg-[#22C55E]/10",
+    failed: "text-[#EF4444] bg-[#EF4444]/10",
+    processing: "text-[#EAB308] bg-[#EAB308]/10",
+    pending: "text-[#64748B] bg-[#64748B]/10",
+  };
+  const cls = colors[status] ?? colors.pending;
+  return (
+    <span className={`text-xs px-2 py-0.5 rounded-full font-medium ${cls}`}>{status}</span>
+  );
+}
+
+const CHART_TOOLTIP_STYLE = {
+  contentStyle: {
+    background: "#060F1A",
+    border: "1px solid #1E3A5F",
+    borderRadius: 8,
+    color: "#E2E8F0",
+    fontSize: 12,
+  },
+  itemStyle: { color: "#94A3B8" },
+  labelStyle: { color: "#E2E8F0", fontWeight: 600, marginBottom: 4 },
+};
+
+// ─── Main ─────────────────────────────────────────────────────────────────────
+
 export default function AdminPage() {
   const { data: session, status } = useSession();
   const router = useRouter();
+
   const [stats, setStats] = useState<Stats | null>(null);
+  const [analytics, setAnalytics] = useState<Analytics | null>(null);
   const [users, setUsers] = useState<AdminUser[]>([]);
   const [selectedUser, setSelectedUser] = useState<AdminUser | null>(null);
   const [submissions, setSubmissions] = useState<Submission[]>([]);
@@ -68,15 +166,14 @@ export default function AdminPage() {
 
   useEffect(() => {
     if (status === "loading") return;
-    if (!session) return; // show sign-in prompt
-    if (!isAdmin) {
-      router.replace("/");
-      return;
-    }
-    Promise.all([getAdminStats(), getAdminUsers()])
-      .then(([s, u]) => {
+    if (!session) return;
+    if (!isAdmin) { router.replace("/"); return; }
+
+    Promise.all([getAdminStats(), getAdminUsers(), getAdminAnalytics()])
+      .then(([s, u, a]) => {
         setStats(s);
         setUsers(u);
+        setAnalytics(a);
       })
       .finally(() => setLoading(false));
   }, [session, status, isAdmin, router]);
@@ -91,6 +188,8 @@ export default function AdminPage() {
       setLoadingSubmissions(false);
     }
   }
+
+  // ── Loading / Auth gates ─────────────────────────────────────────────────
 
   if (status === "loading") {
     return (
@@ -114,64 +213,240 @@ export default function AdminPage() {
     );
   }
 
+  // ── Skeleton ─────────────────────────────────────────────────────────────
+
+  const pulse = "animate-pulse bg-[#0F2235] rounded-xl";
+
+  // ── Derived chart data ───────────────────────────────────────────────────
+
+  const submissionsChartData = analytics?.submissions_30d.map((pt, i) => ({
+    date: shortDate(pt.date),
+    Total: pt.value,
+    Authenticated: analytics.auth_submissions_30d[i]?.value ?? 0,
+    Anonymous: analytics.anon_submissions_30d[i]?.value ?? 0,
+  }));
+
+  const signupsChartData = analytics?.signups_30d.map((pt) => ({
+    date: shortDate(pt.date),
+    Signups: pt.value,
+  }));
+
+  const topEventsChartData = stats?.top_events.map((e) => ({
+    name: e.event_code,
+    count: e.count,
+  }));
+
+  const BAR_COLORS = [
+    "#0073C1", "#0099E6", "#22C55E", "#EAB308", "#F97316",
+    "#EF4444", "#A855F7", "#EC4899", "#14B8A6", "#64748B",
+  ];
+
+  // ── Render ───────────────────────────────────────────────────────────────
+
   return (
     <main className="min-h-screen bg-[#000B14] text-[#E2E8F0]">
-      <header className="px-8 py-6 flex items-center justify-between">
-        <ScorelyLogo />
+      {/* Header */}
+      <header className="px-8 py-5 flex items-center justify-between border-b border-[#1E3A5F]/60">
         <div className="flex items-center gap-4">
-          <span className="text-[#0073C1] text-xs font-semibold uppercase tracking-widest">Admin</span>
-          <AuthButton />
+          <ScorelyLogo />
+          <span className="text-[#0073C1] text-xs font-semibold uppercase tracking-widest px-2 py-0.5 rounded border border-[#0073C1]/40 bg-[#0073C1]/10">
+            Admin
+          </span>
         </div>
+        <AuthButton />
       </header>
 
-      <div className="max-w-6xl mx-auto px-6 py-10 space-y-10">
+      <div className="max-w-7xl mx-auto px-6 py-10 space-y-12">
 
-        {/* Stats cards */}
-        {loading ? (
-          <div className="grid grid-cols-3 gap-4">
-            {[1, 2, 3].map((i) => (
-              <div key={i} className="h-24 rounded-xl bg-[#0F2235] animate-pulse" />
-            ))}
-          </div>
-        ) : stats && (
-          <>
-            <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
-              <StatCard label="Total Users" value={stats.total_users} />
-              <StatCard label="Total Submissions" value={stats.total_submissions} />
-              <StatCard label="Submissions Today" value={stats.submissions_today} />
+        {/* ── KPI Cards ── */}
+        <section>
+          <SectionHeader>Overview</SectionHeader>
+          {loading ? (
+            <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
+              {Array.from({ length: 8 }).map((_, i) => (
+                <div key={i} className={`h-24 ${pulse}`} />
+              ))}
             </div>
+          ) : stats && (
+            <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
+              <StatCard label="Total Users" value={stats.total_users} />
+              <StatCard
+                label="Unique IPs"
+                value={stats.unique_ips}
+                sub="distinct anonymous visitors"
+              />
+              <StatCard label="Total Submissions" value={stats.total_submissions} />
+              <StatCard
+                label="Completion Rate"
+                value={`${stats.completion_rate}%`}
+                accent={
+                  stats.completion_rate >= 80
+                    ? "text-[#22C55E]"
+                    : stats.completion_rate >= 60
+                    ? "text-[#EAB308]"
+                    : "text-[#EF4444]"
+                }
+              />
+              <StatCard label="Submissions Today" value={stats.submissions_today} />
+              <StatCard label="This Week" value={stats.submissions_this_week} />
+              <StatCard
+                label="Authenticated"
+                value={stats.authenticated_submissions}
+                sub="signed-in users"
+                accent="text-[#0073C1]"
+              />
+              <StatCard
+                label="Anonymous"
+                value={stats.anonymous_submissions}
+                sub="no account"
+                accent="text-[#94A3B8]"
+              />
+            </div>
+          )}
+        </section>
 
-            {/* Top events */}
-            {stats.top_events.length > 0 && (
-              <section>
-                <h2 className="text-[#94A3B8] text-xs font-semibold uppercase tracking-widest mb-3">
-                  Top Events
-                </h2>
-                <div className="flex flex-wrap gap-2">
-                  {stats.top_events.map((e) => (
-                    <div
-                      key={e.event_code}
-                      className="px-3 py-1.5 rounded-full bg-[#0F2235] border border-[#1E3A5F] text-sm"
-                    >
-                      <span className="text-[#E2E8F0] font-medium">{e.event_code}</span>
-                      <span className="text-[#64748B] ml-2">{e.count}</span>
-                    </div>
-                  ))}
-                </div>
-              </section>
-            )}
-          </>
+        {/* ── Charts ── */}
+        <section>
+          <SectionHeader>Trends — Last 30 Days</SectionHeader>
+          {loading || !analytics ? (
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+              <div className={`h-64 ${pulse}`} />
+              <div className={`h-64 ${pulse}`} />
+            </div>
+          ) : (
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+              {/* Signups over time */}
+              <div className="bg-[#060F1A] border border-[#1E3A5F] rounded-xl p-5">
+                <p className="text-[#94A3B8] text-xs font-semibold uppercase tracking-widest mb-4">
+                  New Signups
+                </p>
+                <ResponsiveContainer width="100%" height={200}>
+                  <LineChart data={signupsChartData}>
+                    <XAxis
+                      dataKey="date"
+                      tick={{ fill: "#64748B", fontSize: 10 }}
+                      tickLine={false}
+                      axisLine={false}
+                      interval={6}
+                    />
+                    <YAxis
+                      tick={{ fill: "#64748B", fontSize: 10 }}
+                      tickLine={false}
+                      axisLine={false}
+                      allowDecimals={false}
+                      width={24}
+                    />
+                    <Tooltip {...CHART_TOOLTIP_STYLE} />
+                    <Line
+                      type="monotone"
+                      dataKey="Signups"
+                      stroke="#22C55E"
+                      strokeWidth={2}
+                      dot={false}
+                      activeDot={{ r: 4, fill: "#22C55E" }}
+                    />
+                  </LineChart>
+                </ResponsiveContainer>
+              </div>
+
+              {/* Submissions over time */}
+              <div className="bg-[#060F1A] border border-[#1E3A5F] rounded-xl p-5">
+                <p className="text-[#94A3B8] text-xs font-semibold uppercase tracking-widest mb-4">
+                  Submissions
+                </p>
+                <ResponsiveContainer width="100%" height={200}>
+                  <LineChart data={submissionsChartData}>
+                    <XAxis
+                      dataKey="date"
+                      tick={{ fill: "#64748B", fontSize: 10 }}
+                      tickLine={false}
+                      axisLine={false}
+                      interval={6}
+                    />
+                    <YAxis
+                      tick={{ fill: "#64748B", fontSize: 10 }}
+                      tickLine={false}
+                      axisLine={false}
+                      allowDecimals={false}
+                      width={24}
+                    />
+                    <Tooltip {...CHART_TOOLTIP_STYLE} />
+                    <Legend
+                      wrapperStyle={{ fontSize: 11, color: "#94A3B8" }}
+                    />
+                    <Line
+                      type="monotone"
+                      dataKey="Total"
+                      stroke="#0073C1"
+                      strokeWidth={2}
+                      dot={false}
+                      activeDot={{ r: 4 }}
+                    />
+                    <Line
+                      type="monotone"
+                      dataKey="Authenticated"
+                      stroke="#22C55E"
+                      strokeWidth={1.5}
+                      strokeDasharray="4 2"
+                      dot={false}
+                    />
+                    <Line
+                      type="monotone"
+                      dataKey="Anonymous"
+                      stroke="#64748B"
+                      strokeWidth={1.5}
+                      strokeDasharray="4 2"
+                      dot={false}
+                    />
+                  </LineChart>
+                </ResponsiveContainer>
+              </div>
+            </div>
+          )}
+        </section>
+
+        {/* ── Top Events Bar Chart ── */}
+        {!loading && stats && stats.top_events.length > 0 && (
+          <section>
+            <SectionHeader>Top Events by Submissions</SectionHeader>
+            <div className="bg-[#060F1A] border border-[#1E3A5F] rounded-xl p-5">
+              <ResponsiveContainer width="100%" height={220}>
+                <BarChart data={topEventsChartData} barSize={28}>
+                  <XAxis
+                    dataKey="name"
+                    tick={{ fill: "#94A3B8", fontSize: 11 }}
+                    tickLine={false}
+                    axisLine={false}
+                  />
+                  <YAxis
+                    tick={{ fill: "#64748B", fontSize: 10 }}
+                    tickLine={false}
+                    axisLine={false}
+                    allowDecimals={false}
+                    width={28}
+                  />
+                  <Tooltip
+                    {...CHART_TOOLTIP_STYLE}
+                    formatter={(value) => [value, "Submissions"]}
+                  />
+                  <Bar dataKey="count" radius={[4, 4, 0, 0]}>
+                    {topEventsChartData?.map((_, index) => (
+                      <Cell key={index} fill={BAR_COLORS[index % BAR_COLORS.length]} />
+                    ))}
+                  </Bar>
+                </BarChart>
+              </ResponsiveContainer>
+            </div>
+          </section>
         )}
 
-        {/* Users table */}
+        {/* ── Users Table ── */}
         <section>
-          <h2 className="text-[#94A3B8] text-xs font-semibold uppercase tracking-widest mb-4">
-            Users
-          </h2>
+          <SectionHeader>Registered Users ({users.length})</SectionHeader>
           {loading ? (
             <div className="space-y-2">
               {[1, 2, 3, 4].map((i) => (
-                <div key={i} className="h-12 rounded-lg bg-[#0F2235] animate-pulse" />
+                <div key={i} className={`h-12 ${pulse}`} />
               ))}
             </div>
           ) : (
@@ -179,9 +454,9 @@ export default function AdminPage() {
               <table className="w-full text-sm">
                 <thead>
                   <tr className="border-b border-[#1E3A5F]">
-                    <th className="text-left px-4 py-3 text-[#64748B] font-medium">Name</th>
-                    <th className="text-left px-4 py-3 text-[#64748B] font-medium">Email</th>
-                    <th className="text-left px-4 py-3 text-[#64748B] font-medium">Joined</th>
+                    <th className="text-left px-4 py-3 text-[#64748B] font-medium">User</th>
+                    <th className="text-left px-4 py-3 text-[#64748B] font-medium hidden sm:table-cell">Email</th>
+                    <th className="text-left px-4 py-3 text-[#64748B] font-medium hidden md:table-cell">Joined</th>
                     <th className="text-right px-4 py-3 text-[#64748B] font-medium">Submissions</th>
                   </tr>
                 </thead>
@@ -198,15 +473,31 @@ export default function AdminPage() {
                         key={user.id}
                         onClick={() => selectUser(user)}
                         className={`border-b border-[#1E3A5F]/50 cursor-pointer transition-colors ${
-                          selectedUser?.id === user.id
-                            ? "bg-[#0F2235]"
-                            : "hover:bg-[#0A1929]"
+                          selectedUser?.id === user.id ? "bg-[#0F2235]" : "hover:bg-[#0A1929]"
                         }`}
                       >
-                        <td className="px-4 py-3 text-[#E2E8F0]">{user.name}</td>
-                        <td className="px-4 py-3 text-[#94A3B8]">{user.email}</td>
-                        <td className="px-4 py-3 text-[#64748B]">{formatDate(user.created_at)}</td>
-                        <td className="px-4 py-3 text-right text-[#94A3B8]">{user.submission_count}</td>
+                        <td className="px-4 py-3">
+                          <div className="flex items-center gap-2.5">
+                            {user.picture ? (
+                              // eslint-disable-next-line @next/next/no-img-element
+                              <img
+                                src={user.picture}
+                                alt=""
+                                className="w-7 h-7 rounded-full object-cover"
+                              />
+                            ) : (
+                              <div className="w-7 h-7 rounded-full bg-[#1E3A5F] flex items-center justify-center text-xs text-[#94A3B8] font-bold">
+                                {user.name?.[0]?.toUpperCase() ?? "?"}
+                              </div>
+                            )}
+                            <span className="text-[#E2E8F0] font-medium">{user.name}</span>
+                          </div>
+                        </td>
+                        <td className="px-4 py-3 text-[#94A3B8] hidden sm:table-cell">{user.email}</td>
+                        <td className="px-4 py-3 text-[#64748B] hidden md:table-cell">{formatDate(user.created_at)}</td>
+                        <td className="px-4 py-3 text-right">
+                          <span className="text-[#E2E8F0] font-semibold">{user.submission_count}</span>
+                        </td>
                       </tr>
                     ))
                   )}
@@ -216,17 +507,23 @@ export default function AdminPage() {
           )}
         </section>
 
-        {/* Submission drill-down */}
+        {/* ── Submission drill-down ── */}
         {selectedUser && (
           <section>
-            <h2 className="text-[#94A3B8] text-xs font-semibold uppercase tracking-widest mb-4">
-              Submissions — {selectedUser.name}
-            </h2>
+            <div className="flex items-center justify-between mb-4">
+              <SectionHeader>
+                Submissions — {selectedUser.name}
+              </SectionHeader>
+              <button
+                onClick={() => setSelectedUser(null)}
+                className="text-[#64748B] hover:text-[#94A3B8] text-xs transition-colors"
+              >
+                ✕ Close
+              </button>
+            </div>
             {loadingSubmissions ? (
               <div className="space-y-2">
-                {[1, 2, 3].map((i) => (
-                  <div key={i} className="h-10 rounded-lg bg-[#0F2235] animate-pulse" />
-                ))}
+                {[1, 2, 3].map((i) => <div key={i} className={`h-10 ${pulse}`} />)}
               </div>
             ) : (
               <div className="bg-[#060F1A] border border-[#1E3A5F] rounded-xl overflow-hidden">
@@ -250,7 +547,7 @@ export default function AdminPage() {
                       submissions.map((sub) => (
                         <tr key={sub.job_id} className="border-b border-[#1E3A5F]/50">
                           <td className="px-4 py-3">
-                            <span className="text-[#E2E8F0]">{sub.event_code ?? "—"}</span>
+                            <span className="text-[#E2E8F0] font-medium">{sub.event_code ?? "—"}</span>
                             <span className="text-[#64748B] text-xs ml-2">{sub.event_name}</span>
                           </td>
                           <td className="px-4 py-3">
@@ -269,29 +566,8 @@ export default function AdminPage() {
             )}
           </section>
         )}
+
       </div>
     </main>
-  );
-}
-
-function StatCard({ label, value }: { label: string; value: number }) {
-  return (
-    <div className="bg-[#060F1A] border border-[#1E3A5F] rounded-xl px-5 py-4">
-      <p className="text-[#64748B] text-xs mb-1">{label}</p>
-      <p className="text-[#E2E8F0] text-3xl font-bold">{value.toLocaleString()}</p>
-    </div>
-  );
-}
-
-function StatusBadge({ status }: { status: string }) {
-  const colors: Record<string, string> = {
-    complete: "text-[#22C55E] bg-[#22C55E]/10",
-    failed: "text-[#EF4444] bg-[#EF4444]/10",
-    processing: "text-[#EAB308] bg-[#EAB308]/10",
-    pending: "text-[#64748B] bg-[#64748B]/10",
-  };
-  const cls = colors[status] ?? colors.pending;
-  return (
-    <span className={`text-xs px-2 py-0.5 rounded-full font-medium ${cls}`}>{status}</span>
   );
 }

--- a/frontend/app/api/proxy/admin/analytics/route.ts
+++ b/frontend/app/api/proxy/admin/analytics/route.ts
@@ -1,0 +1,15 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getInternalAuthHeader } from "@/lib/internal-token";
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
+
+export async function GET(req: NextRequest) {
+  const authHeader = await getInternalAuthHeader(req);
+  if (!authHeader.Authorization) {
+    return NextResponse.json({ detail: "Unauthorized" }, { status: 401 });
+  }
+
+  const res = await fetch(`${API_URL}/api/admin/analytics`, { headers: authHeader });
+  const data = await res.json();
+  return NextResponse.json(data, { status: res.status });
+}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -74,6 +74,12 @@ export async function getAdminUsers() {
   return res.json();
 }
 
+export async function getAdminAnalytics() {
+  const res = await fetch("/api/proxy/admin/analytics");
+  if (!res.ok) throw new Error("Failed to fetch admin analytics");
+  return res.json();
+}
+
 export async function getAdminUserSubmissions(userId: string) {
   const res = await fetch(`/api/proxy/admin/users/${userId}/submissions`);
   if (!res.ok) throw new Error("Failed to fetch user submissions");

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,7 +11,8 @@
         "next": "16.1.6",
         "next-auth": "^4.24.13",
         "react": "19.2.3",
-        "react-dom": "19.2.3"
+        "react-dom": "19.2.3",
+        "recharts": "^3.8.0"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
@@ -1245,11 +1246,59 @@
         "url": "https://github.com/sponsors/panva"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
+      "integrity": "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.4",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.4.tgz",
+      "integrity": "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
       "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
     },
     "node_modules/@swc/helpers": {
@@ -1543,6 +1592,69 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1578,7 +1690,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -1593,6 +1705,12 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.56.0",
@@ -2608,6 +2726,15 @@
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -2670,8 +2797,129 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -2751,6 +2999,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -3037,6 +3291,16 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.45.1",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.45.1.tgz",
+      "integrity": "sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/escalade": {
       "version": "3.2.0",
@@ -3484,6 +3748,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -3941,6 +4211,16 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -3981,6 +4261,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/is-array-buffer": {
@@ -5570,8 +5859,75 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/recharts": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.0.tgz",
+      "integrity": "sha512-Z/m38DX3L73ExO4Tpc9/iZWHmHnlzWG4njQbxsF5aSjwqmHNDDIm0rdEBArkwsBvR8U6EirlEHiQNYWCVh9sGQ==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
+      }
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
@@ -5616,6 +5972,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.11",
@@ -6206,6 +6568,12 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -6543,6 +6911,15 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/uuid": {
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
@@ -6550,6 +6927,28 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/which": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,7 +12,8 @@
     "next": "16.1.6",
     "next-auth": "^4.24.13",
     "react": "19.2.3",
-    "react-dom": "19.2.3"
+    "react-dom": "19.2.3",
+    "recharts": "^3.8.0"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",


### PR DESCRIPTION
## Summary
- 8 KPI cards: Total Users, Unique IPs, Completion Rate, Today, This Week, Authenticated, Anonymous submissions
- Line charts for signups and submissions (authenticated vs anonymous) over last 30 days
- Bar chart for top events by submission count
- Users table with profile avatars and initials fallback
- New `/api/admin/analytics` backend endpoint with 30-day time-series data
- Extended `/api/admin/stats` with unique IPs, completion rate, weekly totals, and auth/anon split
- Fixed PostgreSQL compatibility (`cast(Date)` instead of SQLite `strftime`)
- Fixed `NEXT_PUBLIC_ADMIN_EMAIL` placeholder that was blocking admin access

## Test plan
- [x] Sign in with admin Google account and navigate to `/admin`
- [x] Verify all 8 KPI cards render with real data
- [x] Verify signups and submissions line charts load
- [ ] Verify top events bar chart renders
- [x] Verify user table shows avatars and clicking a row opens submission drill-down